### PR TITLE
Ensure Mongo documents expose constructors for Spring Data

### DIFF
--- a/backend/incident-service/src/main/java/com/contextsupport/incident/model/ChatMessage.java
+++ b/backend/incident-service/src/main/java/com/contextsupport/incident/model/ChatMessage.java
@@ -3,13 +3,19 @@ package com.contextsupport.incident.model;
 import java.time.Instant;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@AllArgsConstructor(onConstructor = @__(@PersistenceConstructor))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(collection = "messages")
 public class ChatMessage {
 

--- a/backend/incident-service/src/main/java/com/contextsupport/incident/model/EmailRecord.java
+++ b/backend/incident-service/src/main/java/com/contextsupport/incident/model/EmailRecord.java
@@ -4,13 +4,19 @@ import java.time.Instant;
 import java.util.List;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@AllArgsConstructor(onConstructor = @__(@PersistenceConstructor))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(collection = "emails")
 public class EmailRecord {
 

--- a/backend/incident-service/src/main/java/com/contextsupport/incident/model/Incident.java
+++ b/backend/incident-service/src/main/java/com/contextsupport/incident/model/Incident.java
@@ -4,14 +4,20 @@ import java.time.Instant;
 import java.util.List;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.Singular;
 
 @Data
 @Builder
+@AllArgsConstructor(onConstructor = @__(@PersistenceConstructor))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(collection = "incidents")
 public class Incident {
 

--- a/backend/notification-service/src/main/java/com/contextsupport/notification/model/Agent.java
+++ b/backend/notification-service/src/main/java/com/contextsupport/notification/model/Agent.java
@@ -3,13 +3,19 @@ package com.contextsupport.notification.model;
 import java.util.List;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@AllArgsConstructor(onConstructor = @__(@PersistenceConstructor))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(collection = "agents")
 public class Agent {
 

--- a/backend/notification-service/src/main/java/com/contextsupport/notification/model/AgentNotification.java
+++ b/backend/notification-service/src/main/java/com/contextsupport/notification/model/AgentNotification.java
@@ -3,13 +3,19 @@ package com.contextsupport.notification.model;
 import java.time.Instant;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@AllArgsConstructor(onConstructor = @__(@PersistenceConstructor))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(collection = "notifications")
 public class AgentNotification {
 

--- a/backend/sentiment-service/src/main/java/com/contextsupport/sentiment/model/SentimentRecord.java
+++ b/backend/sentiment-service/src/main/java/com/contextsupport/sentiment/model/SentimentRecord.java
@@ -3,13 +3,19 @@ package com.contextsupport.sentiment.model;
 import java.time.Instant;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@AllArgsConstructor(onConstructor = @__(@PersistenceConstructor))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Document(collection = "sentiments")
 public class SentimentRecord {
 


### PR DESCRIPTION
## Summary
- add protected no-args constructors to each Mongo document model
- annotate builder constructors with @PersistenceConstructor-aware @AllArgsConstructor for reliable Spring Data instantiation

## Testing
- mvn clean verify *(fails: network is unreachable for Maven Central)*
- mvn clean verify *(fails: network is unreachable for Maven Central)*
- mvn clean verify *(fails: network is unreachable for Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68cd811d5724832ab0493d8f23607496